### PR TITLE
Initialize Terraform configuration for Talos cluster deployment

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,46 @@
+# Local .terraform directories
+.terraform/
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore output files
+output/
+
+# Ignore .DS_Store files
+.DS_Store
+
+# Ignore .terraform.lock.hcl
+.terraform.lock.hcl

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,62 @@
+module "talos" {
+  source = "./talos"
+
+  providers = {
+    proxmox = proxmox
+  }
+
+  image = {
+    version = "v1.10.0"
+    schematic = file("${path.module}/talos/image/schematic.yaml")
+  }
+
+  cluster = {
+    name            = "polypass"
+    endpoint        = "162.38.112.168"
+    gateway         = "162.38.112.254"
+    private_gateway = "10.15.50.1"
+    talos_version   = "v1.10.0"
+    proxmox_cluster = "serpentard"
+  }
+
+  nodes = {
+    "polypass-ctrl-00" = {
+      host_node     = "serpentard-1"
+      machine_type  = "controlplane"
+      ip            = "10.15.50.110"
+      mac_address   = "BC:24:11:2E:C8:00"
+      secondary_mac_address = "BC:24:11:2E:C8:01"
+      vm_id         = 850
+      cpu           = 4
+      ram_dedicated = 8192
+    }
+    "polypass-work-00" = {
+      host_node     = "serpentard-2"
+      machine_type  = "worker"
+      ip            = "10.15.50.111"
+      mac_address   = "BC:24:11:2E:C8:02"
+      vm_id         = 851
+      cpu           = 8
+      ram_dedicated = 16384
+    }
+    "polypass-work-01" = {
+      host_node     = "serpentard-3"
+      machine_type  = "worker"
+      ip            = "10.15.50.112"
+      mac_address   = "BC:24:11:2E:C8:03"
+      vm_id         = 852
+      cpu           = 8
+      ram_dedicated = 16384
+    }
+    "polypass-work-02" = {
+      host_node     = "serpentard-1"
+      machine_type  = "worker"
+      ip            = "10.15.50.113"
+      mac_address   = "BC:24:11:2E:C8:04"
+      vm_id         = 853
+      cpu           = 8
+      ram_dedicated = 16384
+    }
+
+  }
+}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,28 @@
+resource "local_file" "machine_configs" {
+  for_each        = module.talos.machine_config
+  content         = each.value.machine_configuration
+  filename        = "output/talos-machine-config-${each.key}.yaml"
+  file_permission = "0600"
+}
+
+resource "local_file" "talos_config" {
+  content         = module.talos.client_configuration.talos_config
+  filename        = "output/talos-config.yaml"
+  file_permission = "0600"
+}
+
+resource "local_file" "kube_config" {
+  content         = module.talos.kube_config.kubeconfig_raw
+  filename        = "output/kube-config.yaml"
+  file_permission = "0600"
+}
+
+output "kube_config" {
+  value     = module.talos.kube_config.kubeconfig_raw
+  sensitive = true
+}
+
+output "talos_config" {
+  value     = module.talos.client_configuration.talos_config
+  sensitive = true
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_providers {
+    talos = {
+      source  = "siderolabs/talos"
+      version = "0.7.1"
+    }
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "0.76.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.36.0"
+    }
+    restapi = {
+      source  = "Mastercard/restapi"
+      version = "2.0.1"
+    }
+  }
+}
+
+provider "proxmox" {
+  endpoint = var.proxmox.endpoint
+  insecure = var.proxmox.insecure
+
+  api_token = var.proxmox.api_token
+  ssh {
+    agent    = true
+    username = var.proxmox.username
+  }
+}
+
+provider "kubernetes" {
+  host = module.talos.kube_config.kubernetes_client_configuration.host
+  client_certificate = base64decode(module.talos.kube_config.kubernetes_client_configuration.client_certificate)
+  client_key = base64decode(module.talos.kube_config.kubernetes_client_configuration.client_key)
+  cluster_ca_certificate = base64decode(module.talos.kube_config.kubernetes_client_configuration.ca_certificate)
+}
+
+provider "restapi" {
+  uri                  = var.proxmox.endpoint
+  insecure             = var.proxmox.insecure
+  write_returns_object = true
+
+  headers = {
+    "Content-Type"  = "application/json"
+    "Authorization" = "PVEAPIToken=${var.proxmox.api_token}"
+  }
+}

--- a/terraform/talos/config.tf
+++ b/terraform/talos/config.tf
@@ -1,0 +1,77 @@
+resource "talos_machine_secrets" "this" {
+  talos_version = var.cluster.talos_version
+}
+
+data "talos_client_configuration" "this" {
+  cluster_name         = var.cluster.name
+  client_configuration = talos_machine_secrets.this.client_configuration
+  nodes                = [for k, v in var.nodes : v.ip]
+  endpoints            = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"]
+}
+
+data "talos_machine_configuration" "this" {
+  for_each         = var.nodes
+  cluster_name     = var.cluster.name
+  cluster_endpoint = "https://${var.cluster.endpoint}:6443"
+  talos_version    = var.cluster.talos_version
+  machine_type     = each.value.machine_type
+  machine_secrets  = talos_machine_secrets.this.machine_secrets
+  config_patches   = each.value.machine_type == "controlplane" ? [
+    templatefile("${path.module}/machine-config/control-plane.yaml.tftpl", {
+      hostname       = each.key
+      node_name      = each.value.host_node
+      cluster_name   = var.cluster.proxmox_cluster
+    })
+  ] : [
+    templatefile("${path.module}/machine-config/worker.yaml.tftpl", {
+      hostname     = each.key
+      node_name    = each.value.host_node
+      cluster_name = var.cluster.proxmox_cluster
+    })
+  ]
+}
+
+resource "talos_machine_configuration_apply" "this" {
+  depends_on = [proxmox_virtual_environment_vm.this]
+  for_each                    = var.nodes
+  node                        = each.value.ip
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.this[each.key].machine_configuration
+  lifecycle {
+    # re-run config apply if vm changes
+    replace_triggered_by = [proxmox_virtual_environment_vm.this[each.key]]
+  }
+}
+
+resource "talos_machine_bootstrap" "this" {
+  node                 = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"][0]
+  endpoint             = var.cluster.endpoint
+  client_configuration = talos_machine_secrets.this.client_configuration
+}
+
+data "talos_cluster_health" "this" {
+  depends_on = [
+    talos_machine_configuration_apply.this,
+    talos_machine_bootstrap.this
+  ]
+  client_configuration = data.talos_client_configuration.this.client_configuration
+  control_plane_nodes  = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"]
+  worker_nodes         = [for k, v in var.nodes : v.ip if v.machine_type == "worker"]
+  endpoints            = data.talos_client_configuration.this.endpoints
+  timeouts = {
+    read = "10m"
+  }
+}
+
+resource "talos_cluster_kubeconfig" "this" {
+  depends_on = [
+    talos_machine_bootstrap.this,
+    data.talos_cluster_health.this
+  ]
+  node                 = [for k, v in var.nodes : v.ip if v.machine_type == "controlplane"][0]
+  endpoint             = var.cluster.endpoint
+  client_configuration = data.talos_client_configuration.this.client_configuration
+  timeouts = {
+    read = "1m"
+  }
+}

--- a/terraform/talos/image.tf
+++ b/terraform/talos/image.tf
@@ -1,0 +1,36 @@
+locals {
+  version = var.image.version
+  schematic = var.image.schematic
+  schematic_id = jsondecode(data.http.schematic_id.response_body)["id"]
+  image_id = "${local.schematic_id}_${local.version}"
+
+  update_version = coalesce(var.image.update_version, var.image.version)
+  update_schematic = coalesce(var.image.update_schematic, var.image.schematic)
+  update_schematic_id = jsondecode(data.http.updated_schematic_id.response_body)["id"]
+  update_image_id = "${local.update_schematic_id}_${local.update_version}"
+}
+
+data "http" "schematic_id" {
+  url          = "${var.image.factory_url}/schematics"
+  method       = "POST"
+  request_body = local.schematic
+}
+
+data "http" "updated_schematic_id" {
+  url          = "${var.image.factory_url}/schematics"
+  method       = "POST"
+  request_body = local.update_schematic
+}
+
+resource "proxmox_virtual_environment_download_file" "this" {
+  for_each = toset(distinct([for k, v in var.nodes : "${v.host_node}_${v.update == true ? local.update_image_id : local.image_id}"]))
+
+  node_name    = split("_", each.key)[0]
+  content_type = "iso"
+  datastore_id = var.image.proxmox_datastore
+
+  file_name               = "talos-${split("_",each.key)[1]}-${split("_", each.key)[2]}-${var.image.platform}-${var.image.arch}.img"
+  url = "${var.image.factory_url}/image/${split("_", each.key)[1]}/${split("_", each.key)[2]}/${var.image.platform}-${var.image.arch}.raw.gz"
+  decompression_algorithm = "gz"
+  overwrite               = false
+}

--- a/terraform/talos/image/schematic.yaml
+++ b/terraform/talos/image/schematic.yaml
@@ -1,0 +1,6 @@
+customization:
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/i915-ucode
+      - siderolabs/intel-ucode
+      - siderolabs/qemu-guest-agent

--- a/terraform/talos/machine-config/control-plane.yaml.tftpl
+++ b/terraform/talos/machine-config/control-plane.yaml.tftpl
@@ -1,0 +1,9 @@
+machine:
+  network:
+    hostname: ${hostname}
+  nodeLabels:
+    topology.kubernetes.io/region: ${cluster_name}
+    topology.kubernetes.io/zone: ${node_name}
+
+cluster:
+  allowSchedulingOnControlPlanes: false

--- a/terraform/talos/machine-config/worker.yaml.tftpl
+++ b/terraform/talos/machine-config/worker.yaml.tftpl
@@ -1,0 +1,6 @@
+machine:
+  network:
+    hostname: ${hostname}
+  nodeLabels:
+    topology.kubernetes.io/region: ${cluster_name}
+    topology.kubernetes.io/zone: ${node_name}

--- a/terraform/talos/output.tf
+++ b/terraform/talos/output.tf
@@ -1,0 +1,13 @@
+output "client_configuration" {
+  value     = data.talos_client_configuration.this
+  sensitive = true
+}
+
+output "kube_config" {
+  value     = talos_cluster_kubeconfig.this
+  sensitive = true
+}
+
+output "machine_config" {
+  value = data.talos_machine_configuration.this
+}

--- a/terraform/talos/providers.tf
+++ b/terraform/talos/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = ">=0.60.0"
+    }
+    talos = {
+      source  = "siderolabs/talos"
+      version = ">=0.5.0"
+    }
+  }
+}

--- a/terraform/talos/variables.tf
+++ b/terraform/talos/variables.tf
@@ -1,0 +1,42 @@
+variable "image" {
+  description = "Talos image configuration"
+  type = object({
+    factory_url = optional(string, "https://factory.talos.dev")
+    schematic = string
+    version   = string
+    update_schematic = optional(string)
+    update_version = optional(string)
+    arch = optional(string, "amd64")
+    platform = optional(string, "nocloud")
+    proxmox_datastore = optional(string, "local")
+  })
+}
+
+variable "cluster" {
+  description = "Cluster configuration"
+  type = object({
+    name            = string
+    endpoint        = string
+    gateway         = string
+    private_gateway = string
+    talos_version   = string
+    proxmox_cluster = string
+  })
+}
+
+variable "nodes" {
+  description = "Configuration for cluster nodes"
+  type = map(object({
+    host_node     = string
+    machine_type  = string
+    datastore_id = optional(string, "global")
+    ip            = string
+    mac_address   = string
+    secondary_mac_address = optional(string)
+    vm_id         = number
+    cpu           = number
+    ram_dedicated = number
+    update = optional(bool, false)
+    igpu = optional(bool, false)
+  }))
+}

--- a/terraform/talos/virtual-machines.tf
+++ b/terraform/talos/virtual-machines.tf
@@ -1,0 +1,103 @@
+resource "proxmox_virtual_environment_vm" "this" {
+  for_each = var.nodes
+
+  node_name = each.value.host_node
+
+  name        = each.key
+  description = each.value.machine_type == "controlplane" ? "Talos Control Plane" : "Talos Worker"
+  tags        = each.value.machine_type == "controlplane" ? ["k8s", "talos", "polypass", "control-plane"] : ["k8s", "talos", "polypass", "worker"]
+  on_boot     = true
+  vm_id       = each.value.vm_id
+
+  machine       = "q35"
+  scsi_hardware = "virtio-scsi-single"
+  bios          = "seabios"
+
+  agent {
+    enabled = true
+  }
+
+  cpu {
+    cores = each.value.cpu
+    type  = "host"
+  }
+
+  memory {
+    dedicated = each.value.ram_dedicated
+  }
+
+  network_device {
+    bridge      = "vmbr50"
+    mac_address = each.value.mac_address
+  }
+
+  dynamic "network_device" {
+    for_each = each.value.machine_type == "controlplane" ? [1] : []
+    content {
+      bridge      = "vmbr0"
+      mac_address = each.value.secondary_mac_address
+    }
+  }
+
+  disk {
+    datastore_id = each.value.datastore_id
+    interface    = "scsi0"
+    iothread     = true
+    cache        = "writethrough"
+    discard      = "on"
+    ssd          = true
+    file_format  = "raw"
+    size         = 20
+    file_id      = proxmox_virtual_environment_download_file.this["${each.value.host_node}_${each.value.update == true ? local.update_image_id : local.image_id}"].id
+  }
+
+  boot_order = ["scsi0"]
+
+  operating_system {
+    type = "l26" # Linux Kernel 2.6 - 6.X.
+  }
+
+  dynamic "initialization" {
+    for_each = each.value.machine_type == "controlplane" ? [1] : []
+    content {
+      datastore_id = each.value.datastore_id
+      ip_config {
+        ipv4 {
+          address = "${each.value.ip}/24"
+          gateway = var.cluster.private_gateway
+        }
+      }
+      ip_config {
+        ipv4 {
+          address = "${var.cluster.endpoint}/24"
+          gateway = var.cluster.gateway
+        }
+      }
+    }
+  }
+
+  dynamic "initialization" {
+    for_each = each.value.machine_type == "worker" ? [1] : []
+    content {
+      datastore_id = each.value.datastore_id
+      ip_config {
+        ipv4 {
+          address = "${each.value.ip}/24"
+          gateway = var.cluster.private_gateway
+        }
+      }
+    }
+  }
+
+  dynamic "hostpci" {
+    for_each = each.value.igpu ? [1] : []
+    content {
+      # Passthrough iGPU
+      device  = "hostpci0"
+      mapping = "iGPU"
+      pcie    = true
+      rombar  = true
+      xvga    = false
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "proxmox" {
+  type = object({
+    name         = string
+    cluster_name = string
+    endpoint     = string
+    insecure     = bool
+    username     = string
+    api_token    = string
+  })
+  sensitive = true
+}


### PR DESCRIPTION
This pull request introduces a Terraform configuration for deploying a Kubernetes cluster using Talos and Proxmox. The changes include setting up the necessary providers, defining cluster and node configurations, and implementing resources for virtual machines, machine configurations, and outputs. Below is a summary of the most important changes grouped by theme:

### Provider and Configuration Setup
* Added required providers (`talos`, `proxmox`, `kubernetes`, and `restapi`) in `terraform/providers.tf` and `terraform/talos/providers.tf`, specifying their sources and versions. [[1]](diffhunk://#diff-832814fa1c0667ba9deaf8d383b5c47d12158b43b25f78eb1363418b0e83cc46R1-R49) [[2]](diffhunk://#diff-b9bacff96d99a580270423e363e43f1e417a9e76d40129a6598e8d4553726bc6R1-R12)
* Introduced variables for Proxmox (`terraform/variables.tf`) and Talos cluster (`terraform/talos/variables.tf`) configurations, including sensitive data like API tokens and cluster-specific details. [[1]](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R1-R11) [[2]](diffhunk://#diff-902db1e2ed2c83e4c0697f1ebf234900bada3672bdb11107a258568656be3392R1-R42)

### Talos Cluster and Node Management
* Defined a `module` in `terraform/main.tf` to configure the Talos cluster, specifying cluster details, node configurations, and image details.
* Added resources in `terraform/talos/config.tf` to manage Talos machine secrets, client configurations, machine configurations, and cluster health checks.

### Virtual Machine Provisioning
* Implemented a resource in `terraform/talos/virtual-machines.tf` to create Proxmox virtual machines for control plane and worker nodes, with support for dynamic network and disk configurations.

### Image Management
* Added logic in `terraform/talos/image.tf` to handle Talos image schematics and download the appropriate images for the nodes.

### Outputs and Git Ignore
* Configured sensitive outputs (e.g., `kube_config`, `talos_config`) in `terraform/output.tf` and `terraform/talos/output.tf`. [[1]](diffhunk://#diff-5a78f0b33167a1f4af7c847dc92224c9e67e1715cff84ddfec790a502f50c1d1R1-R28) [[2]](diffhunk://#diff-ab4f78ee06d893176a76208b849fbc3d6aabb2010f0c753c95d0cabcb058d693R1-R13)
* Updated `.gitignore` to exclude Terraform-related sensitive and transient files (e.g., `.tfstate`, `.tfvars`).